### PR TITLE
feat: Add option to ignore certain packages via glob pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +106,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bstr"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +133,7 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "console",
+ "globset",
  "indicatif",
  "miette 7.2.0",
  "node-semver",
@@ -274,6 +294,19 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "globset"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "heck"
@@ -554,6 +587,23 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.21", features = ["derive"] }
 console = "0.15.8"
+globset = "0.4.15"
 indicatif = "0.17.9"
 miette = { version = "7.2.0", features = ["fancy"] }
 node-semver = "2.1.0"

--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ Run the executable with the `check-dep` in the working directory of your Node.js
 can-i-upgrade check-dep --help
 Check if you can upgrade the package in your project
 
-Usage: can-i-upgrade check-dep <PACKAGE_NAME> <TARGET_VERSION>
+Usage: can-i-upgrade check-dep [OPTIONS] <PACKAGE_NAME> <TARGET_VERSION>
 
 Arguments:
   <PACKAGE_NAME>    The name of the npm package to check
   <TARGET_VERSION>  Target Version to check compatibility with
 
 Options:
-  -h, --help  Print help
+  -i, --ignore <IGNORE>  Glob patterns to ignore certain dependencies
+  -h, --help             Print help
 ```
 
 ### Example

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -8,5 +8,8 @@ pub(crate) enum Commands {
         package_name: String,
         /// Target Version to check compatibility with
         target_version: String,
+        /// Glob patterns to ignore certain dependencies
+        #[clap(short = 'i', long = "ignore")]
+        ignore: Vec<String>,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,9 +34,13 @@ fn main() -> Result<()> {
         Commands::CheckDep {
             package_name,
             target_version,
-        } => {
-            commands::check_upgrade::execute(&npm_executable_path, &package_name, &target_version)?
-        }
+            ignore,
+        } => commands::check_upgrade::execute(
+            &npm_executable_path,
+            &package_name,
+            &target_version,
+            ignore,
+        )?,
     }
     Ok(())
 }


### PR DESCRIPTION
This pull request introduces a new feature to ignore certain dependencies using glob patterns when checking for package upgrades. The changes span multiple files to incorporate this functionality.

### New Feature: Ignore Dependencies with Glob Patterns

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R9): Added `globset` dependency to handle glob pattern matching.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R36): Updated usage instructions to include the new `--ignore` option for the `check-dep` command.
* [`src/cli/commands/check_upgrade.rs`](diffhunk://#diff-b074b9cdd7dd71c814620e028dd0c865c6a4e81dc26cfe866d73460019b652abR77): Modified the `execute` function to accept and process `ignore_glob_patterns`, filtering out ignored dependencies using `globset`. [[1]](diffhunk://#diff-b074b9cdd7dd71c814620e028dd0c865c6a4e81dc26cfe866d73460019b652abR77) [[2]](diffhunk://#diff-b074b9cdd7dd71c814620e028dd0c865c6a4e81dc26cfe866d73460019b652abL101-R116)
* [`src/cli/commands/mod.rs`](diffhunk://#diff-38da8705fdf2662e3e19585f900ecaa4856c7edd07d6686cc3a7a8f829fd1653R11-R13): Updated the `Commands` enum to include the `ignore` field for the `check-dep` command.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL37-R43): Passed the `ignore` parameter to the `execute` function in the `check-dep` command.