### PR TITLE
feat: Allow to ignore all pre-release versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Arguments:
 
 Options:
   -i, --ignore <IGNORE>  Glob patterns to ignore certain dependencies
+      --stable           Flag to only include stable versions
   -h, --help             Print help
 ```
 

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -11,5 +11,8 @@ pub(crate) enum Commands {
         /// Glob patterns to ignore certain dependencies
         #[clap(short = 'i', long = "ignore")]
         ignore: Vec<String>,
+        /// Flag to only include stable versions
+        #[clap(long = "stable")]
+        stable: bool,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,11 +35,13 @@ fn main() -> Result<()> {
             package_name,
             target_version,
             ignore,
+            stable,
         } => commands::check_upgrade::execute(
             &npm_executable_path,
             &package_name,
             &target_version,
             ignore,
+            stable,
         )?,
     }
     Ok(())

--- a/src/npm/models.rs
+++ b/src/npm/models.rs
@@ -1,3 +1,4 @@
+use node_semver::Version;
 use std::collections::HashMap;
 
 use crate::node::models::Repository;
@@ -60,7 +61,11 @@ impl ShowPackageInfo {
         None
     }
 
-    pub(crate) fn get_newer_available_versions(&self, current_version_number: &str) -> Vec<String> {
+    pub(crate) fn get_newer_available_versions(
+        &self,
+        current_version_number: &str,
+        only_stable: bool,
+    ) -> Vec<Version> {
         self.versions
             .iter()
             .filter(|version| {
@@ -68,7 +73,19 @@ impl ShowPackageInfo {
                 let current_version = node_semver::Version::parse(current_version_number).unwrap();
                 version > current_version
             })
-            .map(|version| version.to_owned())
+            .map(|version| {
+                let Ok(parsed_version) = version.parse::<Version>() else {
+                    panic!("Invalid version: {version}")
+                };
+                parsed_version
+            })
+            .filter(|v| {
+                if only_stable {
+                    !v.is_prerelease()
+                } else {
+                    true
+                }
+            })
             .collect()
     }
 }


### PR DESCRIPTION
This PR adds an optional argument to the command so that all newer pre-release are ignored so that a user can only check if all newer stable versions are compatible with the target dependency and version. 