### PR TITLE
fix(npm): Prevent even more parsing errors due to optional fields

### DIFF
--- a/src/npm/models.rs
+++ b/src/npm/models.rs
@@ -17,16 +17,19 @@ pub(crate) struct Package {
 pub(crate) struct NpmPackage {
     version: String,
     name: String,
-    dependencies: HashMap<String, Package>,
+    dependencies: Option<HashMap<String, Package>>,
 }
 
 impl NpmPackage {
     pub(crate) fn dependency_names(&self) -> Vec<String> {
-        self.dependencies.keys().cloned().collect()
+        self.dependencies
+            .as_ref()
+            .map(|deps| deps.keys().cloned().collect::<Vec<String>>())
+            .unwrap_or(vec![])
     }
 
     pub(crate) fn get_dependency(&self, name: &str) -> Option<&Package> {
-        self.dependencies.get(name)
+        self.dependencies.as_ref().and_then(|deps| deps.get(name))
     }
 }
 
@@ -40,23 +43,23 @@ pub(crate) struct ShowPackageInfo {
     description: String,
     dist_tags: Option<DistTags>,
     versions: Vec<String>,
-    maintainers: Vec<String>,
+    maintainers: Option<Vec<String>>,
     author: Option<String>,
-    repository: Repository,
+    repository: Option<Repository>,
     pub(crate) version: String,
     #[serde(rename = "peerDependencies")]
-    peer_dependencies: HashMap<String, String>,
+    peer_dependencies: Option<HashMap<String, String>>,
     module: Option<String>,
     typings: Option<String>,
-    dependencies: HashMap<String, String>,
+    dependencies: Option<HashMap<String, String>>,
 }
 
 impl ShowPackageInfo {
     pub(crate) fn get_peer_dependency_version(&self, package_name: &str) -> Option<String> {
-        if let Some(version) = self.peer_dependencies.get(package_name) {
-            return Some(version.to_string());
-        }
-        None
+        self.peer_dependencies
+            .as_ref()
+            .and_then(|peer_deps| peer_deps.get(package_name))
+            .map(|version| version.to_string())
     }
 
     pub(crate) fn get_newer_available_versions(


### PR DESCRIPTION
This pull request includes changes to the `src/npm/models.rs` file to improve the handling of optional fields in the `NpmPackage` and `ShowPackageInfo` structs. The most important changes include modifying the `dependencies`, `maintainers`, `repository`, and `peer_dependencies` fields to be optional, and updating the corresponding methods to handle these optional fields.

Improvements to handling optional fields:

* [`src/npm/models.rs`](diffhunk://#diff-8faac91fa329ea0df09570747383f9508b0d38fa1a67a869067a0059b06e29b4L20-R32): Changed the `dependencies` field in the `NpmPackage` struct to be an `Option<HashMap<String, Package>>` and updated the `dependency_names` and `get_dependency` methods to handle this optional field.
* [`src/npm/models.rs`](diffhunk://#diff-8faac91fa329ea0df09570747383f9508b0d38fa1a67a869067a0059b06e29b4L43-R62): Changed the `maintainers`, `repository`, `peer_dependencies`, and `dependencies` fields in the `ShowPackageInfo` struct to be optional and updated the `get_peer_dependency_version` method to handle the optional `peer_dependencies` field.